### PR TITLE
Modifies habit note size and positioning to accomodate iOS keyboard

### DIFF
--- a/app/components/Note.js
+++ b/app/components/Note.js
@@ -96,7 +96,7 @@ export default class Note extends Component {
                 placeholder="Write a note.."
                 onChangeText={this.onTextChange}
                 defaultValue={this.state.note.note}
-                style={{height: 250, width: 300, fontSize: 18, borderColor: 'white', borderWidth: 1}}
+                style={{height: 175, width: 300, fontSize: 18, borderColor: 'white', borderWidth: 1}}
               />
               <View style={styles.formControls}>
                 <TouchableOpacity
@@ -154,13 +154,13 @@ Note.PropTypes = {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
     padding: 20,
   },
   innerContainer: {
     borderRadius: 10,
-    height: 400,
+    height: 300,
     alignItems: 'center',
+    top: 40,
   },
   modalButton: {
     marginHorizontal: 5,


### PR DESCRIPTION
The iOS keyboard was blocking the 'save', 'delete', and 'trash' buttons in habit notes so the size and positioning of notes has been modified
<img width="283" alt="screen shot 2016-09-08 at 12 31 42 am" src="https://cloud.githubusercontent.com/assets/13752714/18337104/b196eb7c-755b-11e6-9f62-df0d418161d5.png">
